### PR TITLE
Fixed : deprecation of unescaped multiline strings

### DIFF
--- a/stylesheets/decode/types/_string.scss
+++ b/stylesheets/decode/types/_string.scss
@@ -21,8 +21,7 @@
     // If string is not empty
     $string: str-slice($temp, 1, $end - 1);
 
-    $cr: "
-    ";
+    $cr: "\a";
     $string: _strip-token($string, "\\\r", $cr);
     $string: _strip-token($string, "\\\n", $cr);
     $string: _strip-token($string, '\\\"', '"');


### PR DESCRIPTION
Unescaped multiline strings are deprecated and will be removed in a future version of Sass.