### PR TITLE
Removing Deprecation Warning

### DIFF
--- a/dist/_SassyJSON.scss
+++ b/dist/_SassyJSON.scss
@@ -623,8 +623,7 @@
   @else if $end > 1 {
     $string: str-slice($temp, 1, $end - 1);
 
-    $cr: "
-    ";
+    $cr: "\a";
     $string: _strip-token($string, "\r", $cr);
     $string: _strip-token($string, "\n", $cr);
     $string: _strip-token($string, '\\\"', '"');


### PR DESCRIPTION
Compiling with grunt-contrib-sass 0.8.1 throws the following compilation warning:

DEPRECATION WARNING on line 626, column 10 of 
/node_modules/bootcamp/dist/lib/_sassyjson.scss:
Unescaped multiline strings are deprecated and will be removed in a future version of Sass.
To include a newline in a string, use "\a" or "\a " as in CSS.

Replacing the multi-line string with "\a".